### PR TITLE
serialstream reade/write implementation must comply in raised effects…

### DIFF
--- a/src/serial/private/serialport/serialport_common.nim
+++ b/src/serial/private/serialport/serialport_common.nim
@@ -33,7 +33,7 @@ type
 
   TimeoutError* = object of IOError
 
-  InvalidSerialPortStateError* = object of Exception
+  InvalidSerialPortStateError* = object of IOError
 
   InvalidBaudRateError* = object of Exception
 


### PR DESCRIPTION
… to StreamObj (#21)

fixing error of readDataImpl: spReadData:
Error: type mismatch: got <proc (s: Stream, buffer: pointer, bufLen: int): int{.gcsafe, locks: <unknown>.}> but expected 'proc (s: Stream, buffer: pointer, bufLen: int): int{.gcsafe.}'
.raise effects differ